### PR TITLE
VSHA-659: Fix outdated mockup vTDS implementations

### DIFF
--- a/vtds_cluster_mock/private/cluster.py
+++ b/vtds_cluster_mock/private/cluster.py
@@ -388,6 +388,9 @@ class Cluster(ClusterAPI):
         for _, node_class in node_classes.items():
             self.__add_mac_addresses(node_class)
 
+    def consolidate(self):
+        return
+
     def prepare(self):
         self.provider_api = self.stack.get_provider_api()
         self.__add_host_blade_net()


### PR DESCRIPTION
## Summary and Scope

Added implementations for new abstract methods in API classes.

## Issues and Related PRs

* Resolves [VSHA-659](https://jira-pro.it.hpe.com:8443/browse/VSHA-659)

## Testing
### Tested on:

  * Local development environment
  * Github Workflow

### Test description:

* Ran `nox -e lint` and `nox -e style` locally
* Ran same commands as part of github workflow


## Risks and Mitigations

Low - fix what is already broken.

