### PR TITLE
Fix missing API entry / add blade_interconnect() to VirtualNetworks

### DIFF
--- a/vtds_cluster_mock/private/api_objects.py
+++ b/vtds_cluster_mock/private/api_objects.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2024] Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -76,6 +76,9 @@ class VirtualNodes(VirtualNodesBase):
 
     def node_hostname(self, node_class, instance, network_name=None):
         return self.common.node_hostname(node_class, instance, network_name)
+
+    def node_host_blade_info(self, node_class):
+        return self.common.node_host_blade_info(node_class)
 
     def node_ipv4_addr(self, node_class, instance, network_name):
         return self.common.node_ipv4_addr(node_class, instance, network_name)
@@ -194,6 +197,10 @@ class VirtualNetworks(VirtualNetworksBase):
     def non_cluster_network(self, network_name):
         network = self.__network_by_name(network_name)
         return network.get('non_cluster', False)
+
+    def blade_interconnect(self, network_name):
+        network = self.__network_by_name(network_name)
+        return network.get('blade_interconnect', None)
 
     def blade_class_addressing(self, blade_class, network_name):
         network = self.__network_by_name(network_name)

--- a/vtds_cluster_mock/private/common.py
+++ b/vtds_cluster_mock/private/common.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2024] Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -271,6 +271,17 @@ class Common:
         host_blade_class = self.__host_blade_class(node_class)
         virtual_blades = self.stack.get_provider_api().get_virtual_blades()
         return virtual_blades.blade_ssh_key_paths(host_blade_class)
+
+    def node_host_blade_info(self, node_class):
+        """Return the information about the host Virtual Blade on which the
+        specified node lives.
+
+        """
+        instance_capacity = self.__host_blade_instance_capacity(node_class)
+        return {
+            'blade_class': self.__host_blade_class(node_class),
+            'instance_capacity': instance_capacity
+        }
 
     def node_host_blade(self, node_class, instance):
         """Get a tuple containing the the blade class and instance


### PR DESCRIPTION
## Summary and Scope

This PR adds a blade_interconnect() method to the VirtualNetworks API object to allow layers above the Cluster layer to learn the name of the underlying Blade Interconnect supporting a given virtual network.

## Issues and Related PRs

* Partly Resolves [VSHA-701](https://jira-pro.it.hpe.com:8443/browse/VSHA-701)
* Merge after [vtds-base PR 55](https://github.com/Cray-HPE/vtds-base/pull/55)

## Testing

### Tested on:

vTDS

### Test description:

Tested by deploying a mock vTDS stack to verify that the base library changes and this change are compatible.